### PR TITLE
Add missing ellipses to menu action text

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -27,7 +27,7 @@
     </extensions>
 
     <actions>
-        <action id="CleanupBranches" class="com.ppolivka.plugin.gitcleaner.BranchCleanerAction" text="_Delete Old Branches" description="Removes unused branches">
+        <action id="CleanupBranches" class="com.ppolivka.plugin.gitcleaner.BranchCleanerAction" text="_Delete Old Branches..." description="Removes unused branches">
             <add-to-group group-id="Git.Menu"/>
             <add-to-group group-id="Git.ContextMenu"/>
         </action>


### PR DESCRIPTION
Actions in the menu which open dialogs should end with "...".

This is what tells the user that the action will open a dialog before making any changes and is therefore safe to click.