### PR TITLE
doc: where to find the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ It will list all branches that do not have tracking remotes and allow you to del
 Each deleted branch will also do a check if it's fully merged to current branch.
 
 Current branch will not be listed.
+
+Just use the following action: VCS > Git > Delete Old Branches.

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,11 +9,13 @@
       It will list all branches that do not have tracking remotes and allow you to delete them.<br>
       Each deleted branch will also do a check if it's fully merged to current branch.<br>
       Current branch will not be listed.<br>
-      Branches that are not merged to HEAD are not selected by default. <br>
+      Branches that are not merged to HEAD are not selected by default.<br>
+      Just use the following action: VCS > Git > Delete Old Branches.
     ]]></description>
 
     <change-notes><![CDATA[
-      Fix for ArrayIndexOutOfBoundsException when clicking list of branches.
+      * Added user-visible documentation on where to find the action once installed
+      * Fix for ArrayIndexOutOfBoundsException when clicking list of branches
     ]]>
     </change-notes>
 


### PR DESCRIPTION
Hello,

Nowhere in the documentation, website nor IntelliJ is found indication on where to find the action once the plugin is installed.
I had to browse the whole Git sources in order to find it.
This is not needed anymore ;-)

Best regards,
Sébastien.